### PR TITLE
Allow asset separation in single-file components

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extractCSS: process.env.NODE_ENV === 'production'
+};


### PR DESCRIPTION
Adding this file allows you to use
```
<style lang="scss" scoped src="./style.scss">
```
within a single-file component. However `<style lang="scss" scoped src="./style.scss" />` throws a console error:
```
/Users/breadadams/dev/vue-parcel-autoprefixer-example/src/App.vue__type=style&index=0.scss:undefined:undefined: No input specified: provide a file name or a source string to process
```

Not working on `<template>`/`<script>` yet